### PR TITLE
Update JUnit to use aggregator bundle, parameterized empty result test, and refactored some code.

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.blamejared.searchables.gradle.Versions
 
 plugins {
+    java
     id("org.spongepowered.gradle.vanilla") version "0.2.1-SNAPSHOT"
     id("com.blamejared.searchables.default")
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,8 +13,7 @@ minecraft {
 
 dependencies {
     compileOnly("org.spongepowered:mixin:0.8.5")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     testImplementation("org.hamcrest:hamcrest:2.2")
 }
 

--- a/common/src/main/java/com/blamejared/searchables/api/TokenRange.java
+++ b/common/src/main/java/com/blamejared/searchables/api/TokenRange.java
@@ -273,22 +273,22 @@ public final class TokenRange implements Comparable<TokenRange>, Iterable<TokenR
         if(this.subRanges().isEmpty()) {
             return this;
         }
-        int start = this.subRanges()
+        int rangeStart = this.subRanges()
                 .stream()
                 .min(Comparator.comparing(TokenRange::end))
                 .map(TokenRange::start)
                 .orElse(this.start());
-        int end = this.subRanges()
+        int rangeEnd = this.subRanges()
                 .stream()
                 .max(Comparator.comparing(TokenRange::end))
                 .map(TokenRange::end)
                 .orElse(this.end());
         
-        if(start == this.start() && end == this.end()) {
+        if(rangeStart == this.start() && rangeEnd == this.end()) {
             return this;
         }
         
-        TokenRange newRange = TokenRange.between(start, end);
+        TokenRange newRange = TokenRange.between(rangeStart, rangeEnd);
         newRange.subRanges().addAll(this.subRanges());
         return newRange;
     }

--- a/common/src/main/java/com/blamejared/searchables/api/autcomplete/CompletionVisitor.java
+++ b/common/src/main/java/com/blamejared/searchables/api/autcomplete/CompletionVisitor.java
@@ -37,18 +37,15 @@ public class CompletionVisitor implements Visitor<TokenRange>, Consumer<String> 
     protected void reduceTokens() {
         // Can this be done while visiting?
         ListIterator<TokenRange> iterator = tokens.listIterator(tokens.size());
-        TokenRange lastRange = null;
+        TokenRange last = null;
         while(iterator.hasPrevious()) {
             TokenRange previous = iterator.previous();
-            if(lastRange == null) {
-                lastRange = previous;
-            } else {
-                if(lastRange.covers(previous)) {
-                    lastRange.addRange(previous);
-                    iterator.remove();
-                } else {
-                    lastRange = previous;
-                }
+            if (last != null && last.covers(previous)) {
+                last.addRange(previous);
+                iterator.remove();
+            }
+            else {
+                last = previous;
             }
         }
     }

--- a/common/src/test/java/com/blamejared/searchables/tests/SearchTest.java
+++ b/common/src/test/java/com/blamejared/searchables/tests/SearchTest.java
@@ -2,6 +2,8 @@ package com.blamejared.searchables.tests;
 
 import com.blamejared.searchables.TestConstants;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
@@ -12,24 +14,11 @@ import static org.hamcrest.Matchers.hasSize;
 
 public class SearchTest {
     
-    @Test
-    public void testNoResultsDefaultSearch() {
-        
-        List<TestConstants.Shape> shapes = TestConstants.SHAPE.filterEntries(TestConstants.SHAPES, "negative");
-        assertThat(shapes, empty());
-    }
+    @ParameterizedTest
+    @ValueSource(strings = {"negative", "name:invalid", "name:invalid type:square colour:blue"})
+    public void testNoResults(String query) {
     
-    @Test
-    public void testNoResultsComponentSearch() {
-        
-        List<TestConstants.Shape> shapes = TestConstants.SHAPE.filterEntries(TestConstants.SHAPES, "name:invalid");
-        assertThat(shapes, empty());
-    }
-    
-    @Test
-    public void testNoResultsFullSearch() {
-        
-        List<TestConstants.Shape> shapes = TestConstants.SHAPE.filterEntries(TestConstants.SHAPES, "name:invalid type:square colour:blue");
+        List<TestConstants.Shape> shapes = TestConstants.SHAPE.filterEntries(TestConstants.SHAPES, query);
         assertThat(shapes, empty());
     }
     


### PR DESCRIPTION
This PR swaps JUnit to the aggregator bundle. The bundle includes the engine, API, and parameters addon. You can learn more about this [here](https://sormuras.github.io/blog/2018-12-26-junit-jupiter-aggregator.html).

This PR also makes some minor refactors. The first renames variables that were unintentionally shadowing their class variables. The second streamlines reduceTokens by consolidating two of the logic branches into one.

All of your tests should still pass with this PR applied. I also verified that all parameters are being passed to the empty test and verified that including a non-empty search result would cause the test to fail as expected. 